### PR TITLE
feature/grain storage

### DIFF
--- a/src/QueryHive.Silo/Extensions.cs
+++ b/src/QueryHive.Silo/Extensions.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Extensions.Hosting;
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+using QueryHive.Silo.Googler;
 
 namespace QueryHive.Silo;
 public static class Extensions
@@ -8,6 +11,8 @@ public static class Extensions
         builder.AddKeyedRedisClient("hive-redis");
 
         builder.UseOrleans();
+
+        builder.Services.AddSingleton<GooglerMetrics>();
 
         return builder;
     }

--- a/src/QueryHive.Silo/Googler/GooglerGrain.cs
+++ b/src/QueryHive.Silo/Googler/GooglerGrain.cs
@@ -4,34 +4,88 @@ using System.Text;
 
 using Microsoft.Extensions.Logging;
 
+using QueryHive.Silo.Models;
+
 namespace QueryHive.Silo.Googler;
 
-internal sealed partial class GooglerGrain(ILogger<GooglerGrain> logger) : Grain, IGooglerGrain
+internal sealed partial class GooglerGrain(
+    [PersistentState("search-term", "queries")] IPersistentState<SearchTermModel> state,
+    ILogger<GooglerGrain> logger) : Grain, IGooglerGrain
 {
 
     private static readonly CompositeFormat GoogleSearchPageLink = CompositeFormat.Parse("https://www.google.com/?q={0}");
     private static readonly CompositeFormat GoogleSearchResultLink = CompositeFormat.Parse("https://www.google.com/search?q={0}");
-
+    private readonly IPersistentState<SearchTermModel> _state = state;
     private readonly ILogger<GooglerGrain> _logger = logger;
 
-    public ValueTask<Uri> CreateGoogleSearchPageLink()
+    public async ValueTask<string> CreateGoogleSearchPageLink()
     {
-        return CreateUri(GoogleSearchPageLink);
+        if (_state.RecordExists)
+        {
+            Log.StateExists(_logger, _state.Etag, _state.State);
+
+            if (string.IsNullOrEmpty(_state.State.GoogleSearchPageLink))
+            {
+
+                var googleSearchPageLink = CreateUri(GoogleSearchPageLink);
+                //await _state.ClearStateAsync().ConfigureAwait(false);
+                _state.State.GoogleSearchPageLink = googleSearchPageLink;
+                await _state.WriteStateAsync().ConfigureAwait(false);
+                //await _state.ReadStateAsync().ConfigureAwait(false);
+            }
+            var stateUri = _state.State.GoogleSearchPageLink;
+            return stateUri;
+        }
+        var uri = CreateUri(GoogleSearchPageLink);
+        _state.State = new SearchTermModel
+        {
+            Term = this.GetPrimaryKeyString(),
+            GoogleSearchPageLink = uri,
+            GoogleSearchResultLink = string.Empty,
+            CreationDate = DateTimeOffset.UtcNow
+        };
+        await _state.WriteStateAsync().ConfigureAwait(false);
+        return uri;
     }
 
-    public ValueTask<Uri> CreateGoogleSearchResultLink()
+    public async ValueTask<string> CreateGoogleSearchResultLink()
     {
-        return CreateUri(GoogleSearchResultLink);
+        if (_state.RecordExists)
+        {
+            Log.StateExists(_logger, _state.Etag, _state.State);
+
+            if (string.IsNullOrEmpty(_state.State.GoogleSearchResultLink))
+            {
+
+                var googleSearchResultPage = CreateUri(GoogleSearchResultLink);
+                //await _state.ClearStateAsync().ConfigureAwait(false);
+                _state.State.GoogleSearchResultLink = googleSearchResultPage;
+                await _state.WriteStateAsync().ConfigureAwait(false);
+                //await _state.ReadStateAsync().ConfigureAwait(false);
+            }
+            var stateUri = _state.State.GoogleSearchResultLink;
+            return stateUri;
+        }
+        var uri = CreateUri(GoogleSearchResultLink);
+        _state.State = new SearchTermModel
+        {
+            Term = this.GetPrimaryKeyString(),
+            GoogleSearchPageLink = string.Empty,
+            GoogleSearchResultLink = uri,
+            CreationDate = DateTimeOffset.UtcNow
+        };
+        await _state.WriteStateAsync().ConfigureAwait(false);
+        return uri;
     }
 
-    private ValueTask<Uri> CreateUri(CompositeFormat googleUri)
+    private string CreateUri(CompositeFormat googleUri)
     {
         var query = this.GetPrimaryKeyString();
         var result = string.Format(CultureInfo.InvariantCulture, googleUri, query);
-        if (Uri.TryCreate(result, UriKind.Absolute, out var uri))
+        if (Uri.TryCreate(result, UriKind.Absolute, out _))
         {
             Log.UriCreated(_logger);
-            return ValueTask.FromResult(uri);
+            return result;
         }
 
         Log.ErrorCreatingRedirectUri(_logger);
@@ -40,6 +94,12 @@ internal sealed partial class GooglerGrain(ILogger<GooglerGrain> logger) : Grain
 
     private static partial class Log
     {
+        [LoggerMessage(LogLevel.Information,
+            EventId = 11,
+            EventName = "StateAlreadyExists",
+            Message = "State already exists with ETAG: {etag} and value: {state}")]
+        public static partial void StateExists(ILogger logger, string etag, SearchTermModel state);
+
         [LoggerMessage(LogLevel.Debug,
             "Creating redirect URI",
             EventId = 10,

--- a/src/QueryHive.Silo/Googler/GooglerGrain.cs
+++ b/src/QueryHive.Silo/Googler/GooglerGrain.cs
@@ -10,6 +10,7 @@ namespace QueryHive.Silo.Googler;
 
 internal sealed partial class GooglerGrain(
     [PersistentState("search-term", "queries")] IPersistentState<SearchTermModel> state,
+    GooglerMetrics metrics,
     ILogger<GooglerGrain> logger) : Grain, IGooglerGrain
 {
 
@@ -18,6 +19,7 @@ internal sealed partial class GooglerGrain(
 
     private readonly IPersistentState<SearchTermModel> _state = state;
     private readonly ILogger<GooglerGrain> _logger = logger;
+    private readonly GooglerMetrics _metrics = metrics;
 
     public async ValueTask<string> CreateGoogleSearchPageLink()
     {

--- a/src/QueryHive.Silo/Googler/GooglerMetrics.cs
+++ b/src/QueryHive.Silo/Googler/GooglerMetrics.cs
@@ -1,0 +1,16 @@
+﻿using System.Diagnostics.Metrics;
+
+namespace QueryHive.Silo.Googler;
+internal sealed class GooglerMetrics
+{
+    private static readonly string Version = typeof(GooglerMetrics).Assembly.GetName().Version!.ToString(3);
+
+    private readonly Meter _meter;
+
+    public GooglerMetrics(IMeterFactory factory)
+    {
+        _meter = factory.Create("queryhive.searches.googler", version: Version);
+    }
+
+
+}

--- a/src/QueryHive.Silo/Googler/IGooglerGrain.cs
+++ b/src/QueryHive.Silo/Googler/IGooglerGrain.cs
@@ -4,9 +4,9 @@
 public interface IGooglerGrain : IGrainWithStringKey
 {
     [Alias("create-search-page-link")]
-    ValueTask<Uri> CreateGoogleSearchPageLink();
+    ValueTask<string> CreateGoogleSearchPageLink();
 
 
     [Alias("create-search-result-link")]
-    ValueTask<Uri> CreateGoogleSearchResultLink();
+    ValueTask<string> CreateGoogleSearchResultLink();
 }

--- a/src/QueryHive.Silo/Models/SearchTermModel.cs
+++ b/src/QueryHive.Silo/Models/SearchTermModel.cs
@@ -1,6 +1,23 @@
-﻿namespace QueryHive.Silo.Models;
+﻿using System.Text.Json;
 
+namespace QueryHive.Silo.Models;
+
+//[Immutable]
 [GenerateSerializer]
-[Immutable]
 [Alias("QueryHive.Silo.Models.SearchTermModel")]
-public sealed record class SearchTermModel(string Term, DateTimeOffset Timestamp);
+public sealed class SearchTermModel
+{
+    [Id(0)]
+    public required string Term { get; set; }
+    [Id(1)]
+    public required string GoogleSearchPageLink { get; set; }
+    [Id(2)]
+    public required string GoogleSearchResultLink { get; set; }
+    [Id(3)]
+    public DateTimeOffset CreationDate { get; set; }
+
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this);
+    }
+}

--- a/src/QueryHive.Silo/Models/SearchTermModel.cs
+++ b/src/QueryHive.Silo/Models/SearchTermModel.cs
@@ -10,14 +10,41 @@ public sealed class SearchTermModel
     [Id(0)]
     public required string Term { get; set; }
     [Id(1)]
-    public required string GoogleSearchPageLink { get; set; }
+    public required string SearchPage { get; set; }
     [Id(2)]
-    public required string GoogleSearchResultLink { get; set; }
+    public required string ResultPage { get; set; }
     [Id(3)]
     public DateTimeOffset CreationDate { get; set; }
 
     public override string ToString()
     {
         return JsonSerializer.Serialize(this);
+    }
+
+    public bool IsSearchLinkPopulated() => !string.IsNullOrEmpty(SearchPage);
+    public bool IsResultLinkPopulated() => !string.IsNullOrEmpty(ResultPage);
+
+    ///<summary>
+    /// Sets the search link for the search term.
+    /// </summary>
+    /// <param name="link">The search link to set.</param>
+    /// <exception cref="ArgumentException" >Thrown when the link is null or empty.</exception>
+    public void SetSearchLink(string link)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(link, nameof(link));
+
+        SearchPage = link;
+    }
+
+    ///<summary>
+    /// Sets the result link for the search term.
+    /// </summary>
+    /// <param name="link">The search link to set.</param>
+    /// <exception cref="ArgumentException" >Thrown when the link is null or empty.</exception>
+    public void SetResultLink(string link)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(link, nameof(link));
+
+        ResultPage = link;
     }
 }

--- a/test/QueryHive.Grains.Tests/ClusterCollectionFixture.cs
+++ b/test/QueryHive.Grains.Tests/ClusterCollectionFixture.cs
@@ -1,0 +1,7 @@
+﻿namespace QueryHive.Grains.Tests;
+
+[CollectionDefinition(Name)]
+public sealed class ClusterCollectionFixture : ICollectionFixture<ClusterFixture>
+{
+    public const string Name = nameof(ClusterCollectionFixture);
+}

--- a/test/QueryHive.Grains.Tests/ClusterFixture.cs
+++ b/test/QueryHive.Grains.Tests/ClusterFixture.cs
@@ -1,0 +1,23 @@
+﻿using Orleans.TestingHost;
+
+namespace QueryHive.Grains.Tests;
+
+public sealed class ClusterFixture : IDisposable
+{
+    public TestCluster Cluster { get; }
+
+
+    public ClusterFixture()
+    {
+        var builder = new TestClusterBuilder();
+        // Silo configuration
+        builder = builder.AddSiloBuilderConfigurator<TestSiloBuilderConfigurator>();
+        // Client configuration
+        builder = builder.AddClientBuilderConfigurator<TestClientBuilderConfigurator>();
+
+        Cluster = builder.Build();
+        Cluster.Deploy();
+    }
+
+    void IDisposable.Dispose() => Cluster.StopAllSilos();
+}

--- a/test/QueryHive.Grains.Tests/Grains/GooglerGrainTests.cs
+++ b/test/QueryHive.Grains.Tests/Grains/GooglerGrainTests.cs
@@ -1,26 +1,23 @@
-using Microsoft.Extensions.Logging.Abstractions;
-
 using Orleans.TestingHost;
 
 using QueryHive.Silo.Googler;
 
-namespace QueryHive.Grains.Tests;
+namespace QueryHive.Grains.Tests.Grains;
 
-public class GooglerGrainTests
+[Collection(ClusterCollectionFixture.Name)]
+public class GooglerGrainTests(ClusterFixture fixture)
 {
     private const string SampleSearchTerm = "Orleans";
     private const string ExpectedGoogleSearchPageLink = "https://www.google.com/?q=Orleans";
     private const string ExpectedGoogleSearchResultLink = "https://www.google.com/search?q=Orleans";
+
+    private readonly TestCluster _cluster = fixture.Cluster;
+
     [Fact]
     public async Task CreateGoogleSearchPageLink_ShouldReturnValidUri()
     {
-
-        var builder = new TestClusterBuilder();
-        var cluster = builder.Build();
-        cluster.Deploy();
-
         // Arrange
-        var grain = cluster.GrainFactory.GetGrain<IGooglerGrain>(SampleSearchTerm);
+        var grain = _cluster.GrainFactory.GetGrain<IGooglerGrain>(SampleSearchTerm);
 
         // Act
         var result = await grain.CreateGoogleSearchPageLink();
@@ -33,13 +30,8 @@ public class GooglerGrainTests
     [Fact]
     public async Task CreateGoogleSearchResultLink_ShouldReturnValidUri()
     {
-
-        var builder = new TestClusterBuilder();
-        var cluster = builder.Build();
-        cluster.Deploy();
-
         // Arrange
-        var grain = cluster.GrainFactory.GetGrain<IGooglerGrain>(SampleSearchTerm);
+        var grain = _cluster.GrainFactory.GetGrain<IGooglerGrain>(SampleSearchTerm);
 
         // Act
         var result = await grain.CreateGoogleSearchResultLink();

--- a/test/QueryHive.Grains.Tests/TestSiloBuilderConfigurator.cs
+++ b/test/QueryHive.Grains.Tests/TestSiloBuilderConfigurator.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+using Orleans.TestingHost;
+
+namespace QueryHive.Grains.Tests;
+
+internal sealed class TestSiloBuilderConfigurator : ISiloConfigurator
+{
+    public void Configure(ISiloBuilder siloBuilder)
+    {
+        siloBuilder
+        .UseLocalhostClustering()
+        .AddMemoryGrainStorage("queries")
+        .ConfigureServices(static services => services
+            .AddLogging(logger => logger.ClearProviders().AddConsole()));
+    }
+}
+
+internal sealed class TestClientBuilderConfigurator : IClientBuilderConfigurator
+{
+    public void Configure(IConfiguration configuration, IClientBuilder clientBuilder)
+    {
+        clientBuilder.UseLocalhostClustering();
+    }
+}


### PR DESCRIPTION
- **Add grain storage and fuckedup storage update**
  

- **Refactor SearchTermModel and add validation methods**
  Renamed properties in SearchTermModel:
  - GoogleSearchPageLink to SearchPage
  - GoogleSearchResultLink to ResultPage
  
  Added methods:
  - IsSearchLinkPopulated: checks if SearchPage is populated
  - IsResultLinkPopulated: checks if ResultPage is populated
  - SetSearchLink: sets SearchPage with validation
  - SetResultLink: sets ResultPage with validation
  

- **Refactor GooglerGrain: improve readability and error handling**
  # Important note:
  
  NEVER use `ConfigureAwait(false)` in grain code
  directy. Read this document for an in-depth explanation:
  https://learn.microsoft.com/en-us/dotnet/orleans/grains/external-tasks-and-grains#task-based-apis
  
  - Renamed constants for clarity: `GoogleSearchPageLink` to `SearchPageTemplate` and `GoogleSearchResultLink` to `ResultPageTemplate`.
  - Initialized `_state` and `_logger` fields in the constructor.
  - Updated link creation methods to use `IsSearchLinkPopulated` and `IsResultLinkPopulated`.
  - Added `try-catch` block for state update logic with error logging via new `WriteStateThrew` method.
  - Simplified return statements to reduce redundant code.
  - Added `WriteStateThrew` method for standardized error logging.
  

- **Add GooglerMetrics service and integrate with GooglerGrain**
  - Modified `Extensions.cs` to register `GooglerMetrics` as a singleton in the DI container within the `AddQueryHive` method.
  - Updated `GooglerGrain.cs` to inject `GooglerMetrics` and store it in a private readonly field `_metrics`.
  - Created `GooglerMetrics.cs` to define the `GooglerMetrics` class, which uses `System.Diagnostics.Metrics` to track metrics for "queryhive.searches.googler".
  